### PR TITLE
Added QCD pileup reweighting module

### DIFF
--- a/data/qcd_with_weights.json
+++ b/data/qcd_with_weights.json
@@ -1,0 +1,152 @@
+{
+    "v2": {
+        "dy": [],
+        "qcd": [
+            {
+                "min_pt": 0,
+                "max_pt": 9999,
+                "xsec": 78770000000.0,
+                "nr_inclusive": 28572000,
+                "nr_em": 0,
+                "nr_mu": 0,
+                "mu_filt_eff": 0.0,
+                "mu_em_filt_eff": 0.0,
+                "em_filt_eff": 0.0,
+                "em_mu_filt_eff": 0.0
+            },
+            {
+                "min_pt": 15.0,
+                "max_pt": 20.0,
+                "xsec": 884600000.0,
+                "nr_inclusive": 99938035,
+                "nr_em": 0,
+                "nr_mu": 0,
+                "mu_filt_eff": 0.0082,
+                "mu_em_filt_eff": 0.0491,
+                "em_filt_eff": 0.0593,
+                "em_mu_filt_eff": 0.0059
+            },
+            {
+                "min_pt": 20.0,
+                "max_pt": 30.0,
+                "xsec": 416200000.0,
+                "nr_inclusive": 99966512,
+                "nr_em": 0,
+                "nr_mu": 0,
+                "mu_filt_eff": 0.0082,
+                "mu_em_filt_eff": 0.0491,
+                "em_filt_eff": 0.0593,
+                "em_mu_filt_eff": 0.0059
+            },
+            {
+                "min_pt": 30.0,
+                "max_pt": 50.0,
+                "xsec": 112600000.0,
+                "nr_inclusive": 99979672,
+                "nr_em": 0,
+                "nr_mu": 0,
+                "mu_filt_eff": 0.0082,
+                "mu_em_filt_eff": 0.0491,
+                "em_filt_eff": 0.0593,
+                "em_mu_filt_eff": 0.0059
+            },
+            {
+                "min_pt": 50.0,
+                "max_pt": 80.0,
+                "xsec": 16690000.0,
+                "nr_inclusive": 97820760,
+                "nr_em": 0,
+                "nr_mu": 0,
+                "mu_filt_eff": 0.0146,
+                "mu_em_filt_eff": 0.1096,
+                "em_filt_eff": 0.1259,
+                "em_mu_filt_eff": 0.0108
+            },
+            {
+                "min_pt": 80.0,
+                "max_pt": 120.0,
+                "xsec": 2506000.0,
+                "nr_inclusive": 98779820,
+                "nr_em": 0,
+                "nr_mu": 0,
+                "mu_filt_eff": 0.0219,
+                "mu_em_filt_eff": 0.1367,
+                "em_filt_eff": 0.1563,
+                "em_mu_filt_eff": 0.0177
+            },
+            {
+                "min_pt": 120.0,
+                "max_pt": 170.0,
+                "xsec": 440400.0,
+                "nr_inclusive": 99937534,
+                "nr_em": 0,
+                "nr_mu": 0,
+                "mu_filt_eff": 0.0292,
+                "mu_em_filt_eff": 0.1417,
+                "em_filt_eff": 0.1635,
+                "em_mu_filt_eff": 0.0245
+            },
+            {
+                "min_pt": 170.0,
+                "max_pt": 300.0,
+                "xsec": 113000.0,
+                "nr_inclusive": 99977184,
+                "nr_em": 0,
+                "nr_mu": 0,
+                "mu_filt_eff": 0.0358,
+                "mu_em_filt_eff": 0.1426,
+                "em_filt_eff": 0.1595,
+                "em_mu_filt_eff": 0.0316
+            },
+            {
+                "min_pt": 300.0,
+                "max_pt": 470.0,
+                "xsec": 7572.0,
+                "nr_inclusive": 79792436,
+                "nr_em": 0,
+                "nr_mu": 0,
+                "mu_filt_eff": 0.0,
+                "mu_em_filt_eff": 0.0,
+                "em_filt_eff": 0.0,
+                "em_mu_filt_eff": 0.0
+            },
+            {
+                "min_pt": 470.0,
+                "max_pt": 600.0,
+                "xsec": 622.4,
+                "nr_inclusive": 77569564,
+                "nr_em": 0,
+                "nr_mu": 0,
+                "mu_filt_eff": 0.0,
+                "mu_em_filt_eff": 0.0,
+                "em_filt_eff": 0.0,
+                "em_mu_filt_eff": 0.0
+            },
+            {
+                "min_pt": 600.0,
+                "max_pt": 800.0,
+                "xsec": 178.8,
+                "nr_inclusive": 79770286,
+                "nr_em": 0,
+                "nr_mu": 0,
+                "mu_filt_eff": 0.0,
+                "mu_em_filt_eff": 0.0,
+                "em_filt_eff": 0.0,
+                "em_mu_filt_eff": 0.0
+            },
+            {
+                "min_pt": 800.0,
+                "max_pt": 1000.0,
+                "xsec": 30.54,
+                "nr_inclusive": 79505640,
+                "nr_em": 0,
+                "nr_mu": 0,
+                "mu_filt_eff": 0.0,
+                "mu_em_filt_eff": 0.0,
+                "em_filt_eff": 0.0,
+                "em_mu_filt_eff": 0.0
+            }
+        ],
+        "wjets": []
+    }
+}

--- a/interface/QCDWeightCalc.h
+++ b/interface/QCDWeightCalc.h
@@ -1,0 +1,48 @@
+#ifndef L1SCOUTINGANALYZER_L1SCOUTINGANALYZER_QCDWEIGHTCALC_H
+#define L1SCOUTINGANALYZER_L1SCOUTINGANALYZER_QCDWEIGHTCALC_H
+
+#include <string>
+#include <vector>   
+#include <boost/property_tree/ptree.hpp>
+#include "FWCore/ParameterSet/interface/FileInPath.h"
+
+class QCDWeightCalc {
+public:
+  struct PtBinnedSample {
+    float minPt;
+    float maxPt;
+    float xsec;
+    float nrIncl;
+    float nrEm;
+    float emFiltEff;
+    float emMuFiltEff;
+    float nrMu;
+    float muFiltEff;
+    float muEmFiltEff;
+    float nrEmNoMuExpect;
+    float nrEmNoMuActual;
+    float nrMuNoEmExpect;
+    float nrMuNoEmActual;
+    float nrEmMuExpect;
+    float nrEmMuActual;
+  
+    
+    PtBinnedSample(const boost::property_tree::ptree& sampleInfo);
+    void setEnrichedCounts(float nrMinBias,float minBiasXSec);
+  };
+
+  QCDWeightCalc(const char* fullpath,float bxFreq=30E6);
+  float weight(float genPtHat,const std::vector<float>& puPtHats,bool passEm,bool passMu)const;
+  float filtWeight(float genPtHat,bool passEm,bool passMu)const;
+  float operator()(float genPtHat,const std::vector<float>& puPtHats,bool passEm,bool passMu)const{
+    return weight(genPtHat,puPtHats,passEm,passMu);
+  }
+private:
+  size_t getBinNr(float ptHat)const;
+  float bxFreq_;
+  std::vector<PtBinnedSample> bins_;
+  
+};
+
+#endif 
+

--- a/python/QCDWeightCalc.py
+++ b/python/QCDWeightCalc.py
@@ -45,7 +45,6 @@ class QCDWeightProducer(JetLepMetSyst):
                     bool pass_mu = false;
                     std::vector<float> puPtHats;
                     for (int i = 0; i < PileupPtHats.size(); i++){
-                        if (PileupPtHats[i] <= 0.0) continue;
                         puPtHats.push_back(PileupPtHats[i]);
                     }
                     std::sort (puPtHats.begin(), puPtHats.end(), std::greater<float>());

--- a/python/QCDWeightCalc.py
+++ b/python/QCDWeightCalc.py
@@ -1,0 +1,81 @@
+# Calculates xs weights from a given json for QCD samples
+import os
+
+from analysis_tools.utils import import_root, randomize
+from Base.Modules.baseModules import JetLepMetSyst
+
+ROOT = import_root()
+
+class QCDWeightProducer(JetLepMetSyst):
+    def __init__(self, *args, **kwargs):
+        default_name = "qcd_weight"
+
+        default_json_path = os.path.expandvars("$CMSSW_BASE/src/L1DS/Modules/data/qcd_with_weights.json")
+
+        self.json_path = kwargs.pop("json_path", default_json_path)
+        self.json = self.json_path.replace("/", "_").replace(".", "_")
+        self.weight_name = kwargs.pop("weight_name", default_name)
+
+        super(QCDWeightProducer, self).__init__(*args, **kwargs)
+
+        base = "{}/{}/src/L1DS/Modules".format(
+            os.getenv("CMT_CMSSW_BASE"), os.getenv("CMT_CMSSW_VERSION"))
+        
+        if not os.getenv("_L1DSQCD"):
+            os.environ["_L1DSQCD"] = "_L1DSQCD"
+
+            ROOT.gSystem.Load("libL1DSModules.so")
+            ROOT.gROOT.ProcessLine(".L {}/interface/QCDWeightCalc.h".format(base))
+        
+        if not os.getenv("_L1DSQCD_%s" % self.json):
+            os.environ["_L1DSQCD_%s" % self.json] = "_L1DSQCD_%s" % self.json
+
+            ROOT.gInterpreter.Declare("""
+                auto qcd_weight%s = QCDWeightCalc("%s", %f);
+            """ % (self.json, self.json_path, 30E6))
+
+            # Function to calculate weights
+            ROOT.gInterpreter.Declare("""
+                using Vfloat = ROOT::RVec<float>;
+                float get_qcd_weight_%s(
+                    float genPtHat, Vfloat PileupPtHats 
+                ){  
+            
+                    bool pass_em = false;
+                    bool pass_mu = false;
+                    std::vector<float> puPtHats;
+                    for (int i = 0; i < PileupPtHats.size(); i++){
+                        if (PileupPtHats[i] <= 0.0) continue;
+                        puPtHats.push_back(PileupPtHats[i]);
+                    }
+                    std::sort (puPtHats.begin(), puPtHats.end(), std::greater<float>());
+
+                    return qcd_weight%s.weight(genPtHat, puPtHats, pass_em, pass_mu);
+                    
+                    //return 1.0;
+                }
+            """% (self.json, self.json))
+    
+
+
+
+    def run(self, df):
+        #s = randomize("qcd_weight")
+
+        df = df.Define(
+            "qcd_weight", f"""get_qcd_weight_{self.json}(
+                genPtHat, PileupPtHats
+            )"""
+        )
+
+        #df = df.Define(
+        #    "qcd_weight",
+        #    "1.0"
+        #)
+
+        return df, ["qcd_weight"]
+
+
+
+def QCDWeight(*args, **kwargs):
+    return lambda: QCDWeightProducer(*args, **kwargs)

--- a/src/QCDWeightCalc.cc
+++ b/src/QCDWeightCalc.cc
@@ -1,0 +1,167 @@
+#include "L1DS/Modules/interface/QCDWeightCalc.h"
+#include "FWCore/ParameterSet/interface/FileInPath.h"
+
+#include <algorithm>
+#include <boost/property_tree/json_parser.hpp>
+#include <stdexcept>
+#include <iostream>
+
+QCDWeightCalc::PtBinnedSample::PtBinnedSample(const boost::property_tree::ptree& sampleInfo)
+{
+    minPt = sampleInfo.get<float>("min_pt");
+    maxPt = sampleInfo.get<float>("max_pt");
+    xsec = sampleInfo.get<float>("xsec");
+    nrIncl = sampleInfo.get<float>("nr_inclusive",0.);
+    nrEm = sampleInfo.get<float>("nr_em",0.);
+    emFiltEff = sampleInfo.get<float>("em_filt_eff",0.);
+    emMuFiltEff = sampleInfo.get<float>("em_mu_filt_eff",0.);
+    nrMu = sampleInfo.get<float>("nr_mu",0.);
+    muFiltEff = sampleInfo.get<float>("mu_filt_eff",0.);
+    muEmFiltEff = sampleInfo.get<float>("mu_em_filt_eff",0.);
+    nrEmNoMuExpect = 0.;
+    nrEmNoMuActual = 0.;
+    nrMuNoEmExpect = 0.;
+    nrMuNoEmActual = 0.;
+    nrEmMuExpect = 0.;
+    nrEmMuActual = 0.;
+    
+    std::cout <<"minPt "<<minPt<<" nr em "<<nrEm<<" nrIncl "<<nrIncl<<std::endl;
+}
+
+void QCDWeightCalc::PtBinnedSample::setEnrichedCounts(float nrMinBias,float minBiasXSec)
+{
+    auto mbInclCount = [this,nrMinBias,minBiasXSec](const float filtEff){
+        float nrMB = nrMinBias*filtEff*this->xsec/minBiasXSec;
+        float nrIncl = this->nrIncl*filtEff;
+        return nrMB+nrIncl;
+    };
+    
+    nrEmNoMuExpect = mbInclCount(emFiltEff*(1-emMuFiltEff));
+    nrMuNoEmExpect = mbInclCount(muFiltEff*(1-muEmFiltEff));
+    nrEmMuExpect = mbInclCount(emFiltEff*emMuFiltEff);
+    
+    nrEmNoMuActual = nrEmNoMuExpect + nrEm*(1-emMuFiltEff);
+    nrMuNoEmActual = nrMuNoEmExpect + nrMu*(1-muEmFiltEff);
+    nrEmMuActual = nrEmMuExpect + nrEm*emMuFiltEff + nrMu*muEmFiltEff;
+}  
+
+  
+
+
+
+QCDWeightCalc::QCDWeightCalc(const char* fullpath,float bxFreq):
+    bxFreq_(bxFreq)
+{
+    std::string fullPath(fullpath);
+    boost::property_tree::ptree sampleData;
+    boost::property_tree::read_json(fullPath,sampleData);
+    const auto& qcdSamples = sampleData.get_child("v2").get_child("qcd");
+    for(const auto& sample : qcdSamples){
+        bins_.push_back(PtBinnedSample(sample.second));   
+    }
+    std::sort(bins_.begin(),bins_.end(),[](const auto& lhs,const auto& rhs){return lhs.minPt<rhs.minPt;});
+    for(size_t binNr=1;binNr<bins_.size();binNr++){
+        bins_[binNr].setEnrichedCounts(bins_[0].nrIncl,bins_[0].xsec);
+    }
+
+    //small validation check
+    if(!bins_.empty()){
+        if(bins_[0].minPt!=0){
+        throw std::runtime_error("QCDWeightCalc: Error, no MinBias bin defined (as defined by minPt=0)");
+        }
+        auto dups = std::adjacent_find(bins_.begin(),bins_.end(),[](const auto& lhs,const auto& rhs){return lhs.minPt==rhs.minPt;});
+        if(dups!=bins_.end()){
+        throw std::runtime_error("QCDWeightCalc: Error, duplicated pt hat bins, first dupped minPt is "+std::to_string(dups->minPt));
+        }
+    }
+        
+}
+
+
+size_t QCDWeightCalc::getBinNr(float ptHat)const
+{
+    //this function is written assuming
+    //1) the number of bins is small (say <10)
+    //2) that the vast majority of ptHats will be small and thus in bin 0 or 1
+    //also note the minbias bin has an 0 - 9999 pt range we have to take into account it 
+    //overlaps the other bins, more reason to treat it as special
+    for(size_t binNr=1;binNr<bins_.size();binNr++){
+        if(ptHat<bins_[binNr].minPt) return binNr-1;
+        else if(ptHat<bins_[binNr].maxPt) return binNr;
+    }  
+    //not in a QCD binned sample, return 0 for minbias
+    return 0;
+}
+
+float QCDWeightCalc::weight(float genPtHat,const std::vector<float>& puPtHats,bool passEm,bool passMu)const
+{
+    std::vector<float> binCounts(bins_.size()+1,0);
+    for(const auto& ptHat : puPtHats){
+        binCounts[getBinNr(ptHat)]++;
+    }
+    binCounts[getBinNr(genPtHat)]++;
+    const float minBiasXsec = bins_[0].xsec;
+    const float totCount = puPtHats.size()+1;//+1 for the genPtHat
+    float expectEventsMC = 0;
+
+    // DEBUG
+    //float expectEventsMCunweighted = 0;
+    //std::cout << "Number of bins (excluding overflow):  " << bins_.size() << std::endl;
+    //std::cout << "Counts in each bin: "; 
+    //for (size_t i = 0; i < binCounts.size(); i++) {
+    //    std::cout << binCounts[i] << " ";
+    //}
+    //std::cout << std::endl;
+    //std::cout << "Total count: " << totCount << std::endl;
+    // END DEBUG
+
+    for(size_t binNr=0;binNr<bins_.size();binNr++){
+        
+        float binFrac = binCounts[binNr]/totCount;
+        float theoryFrac = bins_[binNr].xsec / minBiasXsec;
+        //dont correct inclusively generated sample
+        float probCorr = binNr!=0 ? binFrac / theoryFrac : 1.;
+        expectEventsMC += bins_[binNr].nrIncl * probCorr;
+
+        // DEBUG
+        //expectEventsMCunweighted += bins_[binNr].nrIncl;
+        //std::cout << "binNr: " << binNr << " binFrac: " << binFrac << " theoryFrac: " << theoryFrac << " probCorr: " << probCorr << " expectEventsMC from bin: " << (bins_[binNr].nrIncl * probCorr) << " expectEventsMC from bin (unweighted): " << (bins_[binNr].nrIncl)  << std::endl;
+        // END DEBUG
+    }
+
+    // DEBUG
+    //std::cout << "expectEventsMC: " << expectEventsMC << " expectEventsMC (unweighted): " << expectEventsMCunweighted << std::endl;
+    // END DEBUG
+    float weight = bxFreq_ / expectEventsMC;
+    if(passEm || passMu){
+        weight *= filtWeight(genPtHat,passEm,passMu);
+    }
+
+    // DEBUG (for 1.0499789 case)
+    if (weight > 0.25){
+      std::cout << "DEBUGGING QCDWeightCalc::weight" << std::endl;
+      std::cout << "genPtHat: " << genPtHat << std::endl;
+      std::cout << "Pileup ptHats: ";
+      for (const auto& ptHat : puPtHats) {
+          std::cout << ptHat << " ";
+      }
+      std::cout << std::endl;
+      std::cout << "Resulting weight: " << weight << std::endl;
+      std::cout << std::endl;
+    }
+    return weight;  
+}
+
+float QCDWeightCalc::filtWeight(float genPtHat,bool passEm,bool passMu)const
+{
+    const auto& bin = bins_[getBinNr(genPtHat)];
+    if(passEm && passMu){
+        return bin.nrEmMuActual!=0 ? bin.nrEmMuExpect/bin.nrEmMuActual : 1.;
+    }else if(passEm && !passMu){
+        return bin.nrEmNoMuActual!=0 ? bin.nrEmNoMuExpect/bin.nrEmNoMuActual : 1.;
+    }else if(!passEm && passMu){
+        return bin.nrMuNoEmActual!=0 ? bin.nrMuNoEmExpect/bin.nrMuNoEmActual : 1.;
+    }else{
+        return 1.;
+    }
+}

--- a/src/QCDWeightCalc.cc
+++ b/src/QCDWeightCalc.cc
@@ -104,17 +104,6 @@ float QCDWeightCalc::weight(float genPtHat,const std::vector<float>& puPtHats,bo
     const float totCount = puPtHats.size()+1;//+1 for the genPtHat
     float expectEventsMC = 0;
 
-    // DEBUG
-    //float expectEventsMCunweighted = 0;
-    //std::cout << "Number of bins (excluding overflow):  " << bins_.size() << std::endl;
-    //std::cout << "Counts in each bin: "; 
-    //for (size_t i = 0; i < binCounts.size(); i++) {
-    //    std::cout << binCounts[i] << " ";
-    //}
-    //std::cout << std::endl;
-    //std::cout << "Total count: " << totCount << std::endl;
-    // END DEBUG
-
     for(size_t binNr=0;binNr<bins_.size();binNr++){
         
         float binFrac = binCounts[binNr]/totCount;
@@ -122,22 +111,15 @@ float QCDWeightCalc::weight(float genPtHat,const std::vector<float>& puPtHats,bo
         //dont correct inclusively generated sample
         float probCorr = binNr!=0 ? binFrac / theoryFrac : 1.;
         expectEventsMC += bins_[binNr].nrIncl * probCorr;
-
-        // DEBUG
-        //expectEventsMCunweighted += bins_[binNr].nrIncl;
-        //std::cout << "binNr: " << binNr << " binFrac: " << binFrac << " theoryFrac: " << theoryFrac << " probCorr: " << probCorr << " expectEventsMC from bin: " << (bins_[binNr].nrIncl * probCorr) << " expectEventsMC from bin (unweighted): " << (bins_[binNr].nrIncl)  << std::endl;
-        // END DEBUG
     }
 
-    // DEBUG
-    //std::cout << "expectEventsMC: " << expectEventsMC << " expectEventsMC (unweighted): " << expectEventsMCunweighted << std::endl;
-    // END DEBUG
     float weight = bxFreq_ / expectEventsMC;
     if(passEm || passMu){
         weight *= filtWeight(genPtHat,passEm,passMu);
     }
 
-    // DEBUG (for 1.0499789 case)
+    // DEBUG (for 1.0499789 case in the 15to20 bin)
+    /*
     if (weight > 0.25){
       std::cout << "DEBUGGING QCDWeightCalc::weight" << std::endl;
       std::cout << "genPtHat: " << genPtHat << std::endl;
@@ -146,9 +128,16 @@ float QCDWeightCalc::weight(float genPtHat,const std::vector<float>& puPtHats,bo
           std::cout << ptHat << " ";
       }
       std::cout << std::endl;
+      std::cout << "binCounts with total count " << totCount << " : ";
+      for (const auto& count : binCounts) {
+          std::cout << count << " ";
+      }
+      std::cout << std::endl;
+      std::cout << "Expected events MC: " << expectEventsMC << std::endl;
       std::cout << "Resulting weight: " << weight << std::endl;
       std::cout << std::endl;
     }
+    */
     return weight;  
 }
 


### PR DESCRIPTION
QCDWeightCalc module introduces cross section weights which are adjusted for the presence of high pT pileup interactions. Uses json defined in data/qcd_with_weights.json to extract dataset cross section and event yields.